### PR TITLE
Kala - Added OpenStruct support to mongomodel

### DIFF
--- a/lib/mongomodel/support/types.rb
+++ b/lib/mongomodel/support/types.rb
@@ -30,7 +30,8 @@ module MongoModel
       ::Array    => Types::Array.new,
       ::Set      => Types::Set.new,
       ::Hash     => Types::Hash.new,
-      ::Rational => Types::Rational.new
+      ::Rational => Types::Rational.new,
+      ::OpenStruct => Types::OpenStruct.new
     }
     
     def self.converter_for(type)

--- a/lib/mongomodel/support/types/openstruct.rb
+++ b/lib/mongomodel/support/types/openstruct.rb
@@ -1,0 +1,17 @@
+module MongoModel
+  module Types
+    class OpenStruct
+      def cast(value)
+        ::OpenStruct.new(value)
+      end
+
+      def to_mongo(value)
+        value.marshal_dump
+      end
+
+      def from_mongo(value)
+        ::OpenStruct.new(value)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implemented MongoModel::Types::OpenStruct class with 'cast', 'from_mongo' and 'to_mongo' methods. Added it to the Types::CONVERTERS list.
