### PR TITLE
Update lib/mongomodel/railtie.rb

### DIFF
--- a/lib/mongomodel/railtie.rb
+++ b/lib/mongomodel/railtie.rb
@@ -58,7 +58,9 @@ module MongoModel
     end
     
     initializer "mongomodel.observers" do |app|
-      MongoModel::EmbeddedDocument.observers = app.config.mongomodel.observers || []
+      if defined?(ActiveModel::Observing)
+        MongoModel::EmbeddedDocument.observers = app.config.mongomodel.observers || []
+      end
     end
 
     # Lazily initialize observer instances


### PR DESCRIPTION
looks like activemodel::observers isn't anymore in rails 4 core!
